### PR TITLE
fix(mongocompat): add str property to object id prototype

### DIFF
--- a/snippets/mongocompat/mongotypes.js
+++ b/snippets/mongocompat/mongotypes.js
@@ -414,6 +414,13 @@ ObjectId.prototype.tojson = function() {
     return this.toString();
 };
 
+Object.defineProperty(ObjectId.prototype, 'str', {
+  enumerable: true,
+  get() {
+    return this.toHexString();
+  }
+});
+
 ObjectId.prototype.valueOf = function() {
     return this.str;
 };


### PR DESCRIPTION
Some of the methods we were polyfilling relied on the non-existent str property of the objectid