### PR TITLE
Final version to be used for PR

### DIFF
--- a/snippets/change-streams-monitor/LICENSE
+++ b/snippets/change-streams-monitor/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Edward Mallia
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/snippets/change-streams-monitor/README.md
+++ b/snippets/change-streams-monitor/README.md
@@ -1,0 +1,184 @@
+# change-stream-monitor
+
+## Index <!-- omit from toc -->
+- [change-stream-monitor](#change-stream-monitor)
+  - [listChangeStreams(extended?: boolean, allUsers?: boolean, nsFilter?: Array)](#listchangestreamsextended-boolean-allusers-boolean-nsfilter-array)
+    - [Sample Output - Normal Mode](#sample-output---normal-mode)
+    - [Sample Output - Extended](#sample-output---extended)
+  - [listChangeStreams.help()](#listchangestreamshelp)
+  - [prettyPrintChangeStreamPipeline(connectionId: any)](#prettyprintchangestreampipelineconnectionid-any)
+    - [Example](#example)
+  - [prettyPrintChangeStreamPipeline.help()](#prettyprintchangestreampipelinehelp)
+  - [ChangeStreamsData.help()](#changestreamsdatahelp)
+  - [ExtendedChangeStreamsData.help()](#extendedchangestreamsdatahelp)
+
+This snippet allows mongosh users to monitor Change Streams on the current server.
+
+On installation of this snippet, the following are available to the user.
+
+## listChangeStreams(extended?: boolean, allUsers?: boolean, nsFilter?: Array<string>)
+
+Prints a table with the currently open Change Streams. Note that the table resizes itself based on the size of the terminal.
+
+The behaviour of the function can be controlled with the available parameters (see parameter defaults for default behaviour). See prettyPrintChangeStreamPipeline() to pretty print a change stream pipeline. See ChangeStreamsData and ExtendedChangeStreamsData for data outputted in extended and non-extended mode.
+
+* *extended* - Controls whether a simple or extended output is presented. Refer to ExtendedChangeStreamsData. Defaults to false.
+* *allUsers* - Boolean that correspond's to the allUsers flag of the $currentOp MongoDB Pipeline Stage i.e. If set to false, $currentOp only reports on operations/idle connections/idle cursors/idle sessions belonging to the user who ran the command. If set to true, $currentOp reports operations belonging to all users. Defailts to true.
+* *nsFilter* - An optional array of namespace filter. Defaults to [] i.e. to filter.
+
+| Column Name    | Extended Output | Description                                                                                                                                                              |
+|----------------|-----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ConnID         | No              | An identifier for the connection where the specific operation originated.                                                                                                |
+| AppName        | No              | The identifier of the client application which ran the operation. Use the appName connection string option to set a custom value for the appName field.                  |
+| Remote         | No              | The IP address (or hostname) and the ephemeral port of the client connection where the operation originates.                                                             |
+| Driver         | No              | The MongoDB Driver used to connect and run the Change Stream.                                                                                                            |
+| NS             | No              |  The namespace the operation targets. A namespace consists of the database name and the collection name concatenated with a dot (.); that is, "<database>.<collection>". |
+| Type           | No              | The type of operation. Values are either: op / idleSession / idleCursor.                                                                                                 |
+| Pipeline       | No              | The Change Stream pipeline. Use prettyPrintChangeStreamPipeline(connId) to pretty print the full pipeline.                                                               |
+| LastAccessDate | No              | The date and time when the cursor was last used.                                                                                                                         |
+| Docs Returned  | No              | The cumulative number of documents returned by the cursor.                                                                                                               |
+| Active         | Yes             | A boolean value specifying whether the operation has started.                                                                                                            |
+| User           | Yes             | Users associated with the operation                                                                                                                                      |
+| CursorId       | Yes             | The ID of the cursor.                                                                                                                                                    |
+| CreatedDate    | Yes             | The date and time when the cursor was created.                                                                                                                           |
+
+
+### Sample Output - Normal Mode
+
+```
+replset [primary] test> listChangeStreams()
+  ┏━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
+  ┃  ConnID   ┃  AppName   ┃  Remote      ┃  Driver      ┃  NS          ┃  Type  ┃  Pipeline    ┃  LastAccess  ┃  DocsReturn  ┃
+  ┃           ┃            ┃              ┃              ┃              ┃        ┃              ┃  Date        ┃  ed          ┃
+  ┡━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━┩
+  │  74       │  cs2       │  127.0.0.1:  │  mongo-java  │  test.event  │  op    │  [           │  "2024-04-2  │  0           │
+  │           │            │  54989       │  -driver|sy  │  s           │        │  {           │  2T13:23:10  │              │
+  │           │            │              │  nc: 4.9.1   │              │        │  "$changeSt  │  .160Z"      │              │
+  │           │            │              │              │              │        │  ream": {}   │              │              │
+  │           │            │              │              │              │        │  },          │              │              │
+  │           │            │              │              │              │        │  {           │              │              │
+  │           │            │              │              │              │        │  "$match":   │              │              │
+  │           │            │              │              │              │        │  {           │              │              │
+  │           │            │              │              │              │        │  "operation  │              │              │
+  │           │            │              │              │              │        │  Type": {    │              │              │
+  │           │            │              │              │              │        │  "$in": [    │              │              │
+  │           │            │              │              │              │        │  "insert",   │              │              │
+  │           │            │              │              │              │        │  "update"    │              │              │
+  │           │            │              │              │              │        │  ]           │              │              │
+  │           │            │              │              │              │        │  }           │              │              │
+  │           │            │              │              │              │        │  }           │              │              │
+  │           │            │              │              │              │        │  }           │              │              │
+  │           │            │              │              │              │        │  ]           │              │              │
+  ├───────────┼────────────┼──────────────┼──────────────┼──────────────┼────────┼──────────────┼──────────────┼──────────────┤
+  │  79       │  cs1       │  127.0.0.1:  │  mongo-java  │  test.event  │  op    │  [           │  "2024-04-2  │  0           │
+  │           │            │  55011       │  -driver|sy  │  s           │        │  {           │  2T13:23:10  │              │
+  │           │            │              │  nc: 4.9.1   │              │        │  "$changeSt  │  .181Z"      │              │
+  │           │            │              │              │              │        │  ream": {}   │              │              │
+  │           │            │              │              │              │        │  },          │              │              │
+  │           │            │              │              │              │        │  {           │              │              │
+  │           │            │              │              │              │        │  "$match":   │              │              │
+  │           │            │              │              │              │        │  {           │              │              │
+  │           │            │              │              │              │        │  "operation  │              │              │
+  │           │            │              │              │              │        │  Type": {    │              │              │
+  │           │            │              │              │              │        │  "$in": [    │              │              │
+  │           │            │              │              │              │        │  "insert",   │              │              │
+  │           │            │              │              │              │        │  "update"    │              │              │
+  │           │            │              │              │              │        │  ]           │              │              │
+  │           │            │              │              │              │        │  }           │              │              │
+  │           │            │              │              │              │        │  }           │              │              │
+  │           │            │              │              │              │        │  }           │              │              │
+  │           │            │              │              │              │        │  ]           │              │              │
+  └───────────┴────────────┴──────────────┴──────────────┴──────────────┴────────┴──────────────┴──────────────┴──────────────┘
+Found 2 change streams
+```
+
+### Sample Output - Extended
+
+```
+replset [primary] test> listChangeStreams(true)
+  ┏━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━┓
+  ┃  ConnID  ┃  AppNam  ┃  Remote  ┃  Driver  ┃  NS      ┃  Type  ┃  Pipeli  ┃  LastAc  ┃  DocsRe  ┃  Active  ┃  User    ┃  Cursor  ┃  Create  ┃
+  ┃          ┃  e       ┃          ┃          ┃          ┃        ┃  ne      ┃  cessDa  ┃  turned  ┃          ┃          ┃  Id      ┃  dDate   ┃
+  ┃          ┃          ┃          ┃          ┃          ┃        ┃          ┃  te      ┃          ┃          ┃          ┃          ┃          ┃
+  ┡━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━┩
+  │  74      │  cs2     │  127.0.  │  mongo-  │  test.e  │  op    │  [       │  "2024-  │  0       │  true    │  john@a  │  754369  │  "2024-  │
+  │          │          │  0.1:54  │  java-d  │  vents   │        │  {       │  04-22T  │          │          │  dmin    │  716098  │  04-22T  │
+  │          │          │  989     │  river|  │          │        │  "$chan  │  13:24:  │          │          │          │  703700  │  12:15:  │
+  │          │          │          │  sync:   │          │        │  geStre  │  25.528  │          │          │          │  0       │  31.896  │
+  │          │          │          │  4.9.1   │          │        │  am":    │  Z"      │          │          │          │          │  Z"      │
+  │          │          │          │          │          │        │  {}      │          │          │          │          │          │          │
+  │          │          │          │          │          │        │  },      │          │          │          │          │          │          │
+  │          │          │          │          │          │        │  {       │          │          │          │          │          │          │
+  │          │          │          │          │          │        │  "$matc  │          │          │          │          │          │          │
+  │          │          │          │          │          │        │  h": {   │          │          │          │          │          │          │
+  │          │          │          │          │          │        │  "opera  │          │          │          │          │          │          │
+  │          │          │          │          │          │        │  tionTy  │          │          │          │          │          │          │
+  │          │          │          │          │          │        │  pe": {  │          │          │          │          │          │          │
+  │          │          │          │          │          │        │  "$in":  │          │          │          │          │          │          │
+  │          │          │          │          │          │        │  [       │          │          │          │          │          │          │
+  │          │          │          │          │          │        │  "inser  │          │          │          │          │          │          │
+  │          │          │          │          │          │        │  t",     │          │          │          │          │          │          │
+  │          │          │          │          │          │        │  "updat  │          │          │          │          │          │          │
+  │          │          │          │          │          │        │  e"      │          │          │          │          │          │          │
+  │          │          │          │          │          │        │  ]       │          │          │          │          │          │          │
+  │          │          │          │          │          │        │  }       │          │          │          │          │          │          │
+  │          │          │          │          │          │        │  }       │          │          │          │          │          │          │
+  │          │          │          │          │          │        │  }       │          │          │          │          │          │          │
+  │          │          │          │          │          │        │  ]       │          │          │          │          │          │          │
+  ├──────────┼──────────┼──────────┼──────────┼──────────┼────────┼──────────┼──────────┼──────────┼──────────┼──────────┼──────────┼──────────┤
+  │  79      │  cs1     │  127.0.  │  mongo-  │  test.e  │  op    │  [       │  "2024-  │  0       │  true    │  mary@a  │  697267  │  "2024-  │
+  │          │          │  0.1:55  │  java-d  │  vents   │        │  {       │  04-22T  │          │          │  dmin    │  149292  │  04-22T  │
+  │          │          │  011     │  river|  │          │        │  "$chan  │  13:24:  │          │          │          │  716100  │  12:16:  │
+  │          │          │          │  sync:   │          │        │  geStre  │  25.542  │          │          │          │  0       │  01.889  │
+  │          │          │          │  4.9.1   │          │        │  am":    │  Z"      │          │          │          │          │  Z"      │
+  │          │          │          │          │          │        │  {}      │          │          │          │          │          │          │
+  │          │          │          │          │          │        │  },      │          │          │          │          │          │          │
+  │          │          │          │          │          │        │  {       │          │          │          │          │          │          │
+  │          │          │          │          │          │        │  "$matc  │          │          │          │          │          │          │
+  │          │          │          │          │          │        │  h": {   │          │          │          │          │          │          │
+  │          │          │          │          │          │        │  "opera  │          │          │          │          │          │          │
+  │          │          │          │          │          │        │  tionTy  │          │          │          │          │          │          │
+  │          │          │          │          │          │        │  pe": {  │          │          │          │          │          │          │
+  │          │          │          │          │          │        │  "$in":  │          │          │          │          │          │          │
+  │          │          │          │          │          │        │  [       │          │          │          │          │          │          │
+  │          │          │          │          │          │        │  "inser  │          │          │          │          │          │          │
+  │          │          │          │          │          │        │  t",     │          │          │          │          │          │          │
+  │          │          │          │          │          │        │  "updat  │          │          │          │          │          │          │
+  │          │          │          │          │          │        │  e"      │          │          │          │          │          │          │
+  │          │          │          │          │          │        │  ]       │          │          │          │          │          │          │
+  │          │          │          │          │          │        │  }       │          │          │          │          │          │          │
+  │          │          │          │          │          │        │  }       │          │          │          │          │          │          │
+  │          │          │          │          │          │        │  }       │          │          │          │          │          │          │
+  │          │          │          │          │          │        │  ]       │          │          │          │          │          │          │
+  └──────────┴──────────┴──────────┴──────────┴──────────┴────────┴──────────┴──────────┴──────────┴──────────┴──────────┴──────────┴──────────┘
+Found 2 change streams
+```
+
+## listChangeStreams.help()
+Provides help on how to use the function.
+
+## prettyPrintChangeStreamPipeline(connectionId: any)
+
+Pretty prints the Change Stream pipeline for a given Connection ID.
+* *connectionId* - The connection ID where the change stream is executing.
+
+### Example
+
+```
+replset [primary] test> prettyPrintChangeStreamPipeline(74)
+[
+  { '$changeStream': {} },
+  {
+    '$match': { operationType: { '$in': [ 'insert', 'update' ] } }
+  }
+]
+```
+
+## prettyPrintChangeStreamPipeline.help()
+Provides help on how to use the function.
+
+## ChangeStreamsData.help()
+Describes the table output in normal mode.
+
+## ExtendedChangeStreamsData.help()
+Describes the table output in extended mode.

--- a/snippets/change-streams-monitor/changestreammonitor.js
+++ b/snippets/change-streams-monitor/changestreammonitor.js
@@ -1,0 +1,377 @@
+const localRequire = require("module").createRequire(__filename);
+const { Table } = localRequire("to-tabel");
+const { templates } = localRequire("boks");
+
+function _listChangeStreams (extended = false, allUsers = true, nsFilter = []) {
+  tableData = [];
+  let changeStreamsDataRaw = getChangeStreams(allUsers, nsFilter);
+
+  changeStreamsDataRaw.forEach(changeStreamOpData => {
+    let clientDriver = "N/A";
+    try {
+      clientDriver =
+        changeStreamOpData.clientMetadata.driver.name +
+        ": " +
+        changeStreamOpData.clientMetadata.driver.version;
+    } catch (error) {}
+
+    //format the pipeline for better rendering
+    let changeStreamPipeline = EJSON.stringify(
+      changeStreamOpData.cursor.originatingCommand.pipeline,
+      null,
+      1
+    );
+
+    let usersStr = "";
+    if (changeStreamOpData.effectiveUsers){
+      changeStreamOpData.effectiveUsers.forEach(user => {
+        if (usersStr !== "") usersStr+= "; ";
+        usersStr = usersStr + user.user + "@" + user.db;
+      });
+    }
+
+    if (extended) {
+      tableData.push(
+        new ExtendedChangeStreamsData(
+          changeStreamOpData.connectionId,
+          changeStreamOpData.appName,
+          changeStreamOpData.client,
+          clientDriver,
+          changeStreamOpData.ns,
+          changeStreamOpData.type,
+          changeStreamPipeline,
+          changeStreamOpData.cursor.lastAccessDate,
+          changeStreamOpData.cursor.nDocsReturned,
+          changeStreamOpData.active,
+          usersStr,
+          changeStreamOpData.cursor.cursorId,
+          changeStreamOpData.cursor.createdDate
+        )
+      );
+    } else {
+      tableData.push(
+        new ChangeStreamsData(
+          changeStreamOpData.connectionId,
+          changeStreamOpData.appName,
+          changeStreamOpData.client,
+          clientDriver,
+          changeStreamOpData.ns,
+          changeStreamOpData.type,
+          changeStreamPipeline,
+          changeStreamOpData.cursor.lastAccessDate,
+          changeStreamOpData.cursor.nDocsReturned
+        )
+      );
+    }
+    
+  })
+
+  customConsoleTable(tableData, extended);
+  print("Found " + changeStreamsDataRaw.length + " change streams");
+};
+
+function _listChangeStreamsHelp(){
+  print("listChangeStreams(extended?: boolean, allUsers?: boolean, nsFilter?: any): void")
+  print("Prints a table with the currently open Change Streams. The behaviour of the function can be controlled with the available parameters (see parameter defaults for default behaviour).")
+  print("\t See prettyPrintChangeStreamPipeline.help() to pretty print a change stream pipeline. ")
+  print("\t See ChangeStreamsData.help() and ExtendedChangeStreamsData.help() for data outputted in extended and non-extended mode.")
+  print("\t @param extended — Controls whether a simple or extended output is presented. Refer to ExtendedChangeStreamsData. Defaults to false.")
+  print("\t @param allUsers — Boolean that correspond's to the allUsers flag of the $currentOp MongoDB Pipeline Stage i.e. If set to false, $currentOp only reports on operations/idle connections/idle cursors/idle sessions belonging to the user who ran the command. If set to true, $currentOp reports operations belonging to all users. Defailts to true.")
+  print("\t @param nsFilter — An optional array of namespace filter. Defaults to [] i.e. to filter.")
+}
+
+/**
+ * Prints a table with the currently open Change Streams. The behaviour of the function can be controlled with the available parameters (see parameter defaults for default behaviour). 
+ * See prettyPrintChangeStreamPipeline() to pretty print a change stream pipeline.
+ * See ChangeStreamsData and ExtendedChangeStreamsData for data outputted in extended and non-extended mode.
+ * @param {boolean} extended Controls whether a simple or extended output is presented. Refer to ExtendedChangeStreamsData. Defaults to false.
+ * @param {boolean} allUsers Boolean that correspond's to the allUsers flag of the $currentOp MongoDB Pipeline Stage i.e. 
+ *                     If set to false, $currentOp only reports on operations/idle connections/idle cursors/idle sessions belonging to the user who ran the command.
+ *                     If set to true, $currentOp reports operations belonging to all users.
+ *                     Defailts to true.
+ * @param {Array.<string>} nsFilter An optional array of namespace filter. Defaults to [] i.e. to filter.
+ */
+globalThis.listChangeStreams = function (extended = false, allUsers = true, nsFilter = []) {_listChangeStreams(extended, allUsers, nsFilter);}
+globalThis.listChangeStreams.help = function () {_listChangeStreamsHelp();}
+
+/**
+ * @class Contains the data that will be presented in tabular format. This is the basic data set - @see {ExtendedChangeStreamsData} for the extended version.
+ * @param {*} connId An identifier for the connection where the specific operation originated.
+ * @param {*} appName The identifier of the client application which ran the operation. Use the appName connection string option to set a custom value for the appName field.
+ * @param {*} clientIp The IP address (or hostname) and the ephemeral port of the client connection where the operation originates.
+ * @param {*} clientDriver The MongoDB Driver used to connect and run the Change Stream.
+ * @param {*} ns The namespace the operation targets. A namespace consists of the database name and the collection name concatenated with a dot (.); that is, "<database>.<collection>".
+ * @param {*} type The type of operation. Values are either: op / idleSession / idleCursor.
+ * @param {*} pipeline The Change Stream pipeline. Use prettyPrintChangeStreamPipeline(connId) to pretty print the full pipeline.
+ * @param {*} lastAccessDate The date and time when the cursor was last used.
+ * @param {*} nDocsReturned The cumulative number of documents returned by the cursor.
+ */
+class ChangeStreamsData {
+  constructor(
+    connId,
+    appName,
+    clientIp,
+    clientDriver,
+    ns,
+    type,
+    pipeline,
+    lastAccessDate,
+    nDocsReturned
+  ) {
+    this.connId = connId;
+    this.appName = appName;
+    this.clientIp = clientIp;
+    this.clientDriver = clientDriver;
+    this.ns = ns;
+    this.type = type;
+    this.pipeline = pipeline;
+    this.lastAccessDate = lastAccessDate;
+
+    if (nDocsReturned && nDocsReturned instanceof Long) {
+      this.nDocsReturned = nDocsReturned.toNumber();
+    } else {
+      this.nDocsReturned = nDocsReturned;
+    }
+  }
+
+  static headers() {
+    return [
+      { name: "connId", printName: "ConnID", description: "An identifier for the connection where the specific operation originated." },
+      { name: "appName", printName: "AppName", description: "The identifier of the client application which ran the operation. Use the appName connection string option to set a custom value for the appName field." },
+      { name: "clientIp", printName: "Remote", description: "The IP address (or hostname) and the ephemeral port of the client connection where the operation originates." },
+      { name: "clientDriver", printName: "Driver", description: "The MongoDB Driver used to connect and run the Change Stream." },
+      { name: "ns", printName: "NS", description: "The namespace the operation targets. A namespace consists of the database name and the collection name concatenated with a dot (.); that is, \"<database>.<collection>\"." },
+      { name: "type", printName: "Type", description: "The type of operation. Values are either: op / idleSession / idleCursor." },
+      { name: "pipeline", printName: "Pipeline", description: "The Change Stream pipeline. Use prettyPrintChangeStreamPipeline(connId) to pretty print the full pipeline." },
+      { name: "lastAccessDate", printName: "LastAccessDate", description: "The date and time when the cursor was last used." },
+      { name: "nDocsReturned", printName: "DocsReturned", description: "The cumulative number of documents returned by the cursor." },
+    ];
+  }
+
+  static help(){
+    const options = {
+      maxSize: process.stdout.columns - 10,
+      borders: [templates.bold, templates.single],
+      columns: [{name: "printName", printName: "Column Name"}, {name: "description", printName: "Description"}],
+      maxDepth: 1,
+      fill: true,
+      inclusive: true,
+    };
+
+    let newTbl = new Table(ChangeStreamsData.headers(), options);
+    newTbl.print();
+  }
+};
+
+globalThis.ChangeStreamsData = ChangeStreamsData;
+
+/**
+ * @class
+ * @extends {ChangeStreamsData}
+ * @param {*} connId @see {ChangeStreamsData#connId}
+ * @param {*} appName @see {ChangeStreamsData#appName}
+ * @param {*} clientIp @see {ChangeStreamsData#clientIp}
+ * @param {*} clientDriver @see {ChangeStreamsData#clientDriver}
+ * @param {*} ns @see {ChangeStreamsData#ns}
+ * @param {*} type @see {ChangeStreamsData#type}
+ * @param {*} pipeline @see {ChangeStreamsData#pipeline}
+ * @param {*} lastAccessDate @see {ChangeStreamsData#lastAccessDate}
+ * @param {*} nDocsReturned @see {ChangeStreamsData#nDocsReturned}
+ * @param {*} active A boolean value specifying whether the operation has started.
+ * @param {*} users Users associated with the operation
+ * @param {*} cursorId The ID of the cursor.
+ * @param {*} createdDate The date and time when the cursor was created.
+ */
+class ExtendedChangeStreamsData extends ChangeStreamsData {
+  constructor(
+    connId,
+    appName,
+    clientIp,
+    clientDriver,
+    ns,
+    type,
+    pipeline,
+    lastAccessDate,
+    nDocsReturned,
+    active,
+    users,
+    cursorId,
+    createdDate
+  ) {
+    super(
+      connId,
+      appName,
+      clientIp,
+      clientDriver,
+      ns,
+      type,
+      pipeline,
+      lastAccessDate,
+      nDocsReturned
+    );
+    this.active = active;
+    this.users = users;
+
+    if (cursorId && cursorId instanceof Long) {
+      this.cursorId = cursorId.toNumber();
+    } else {
+      this.cursorId = cursorId;
+    }
+
+    this.createdDate = createdDate;
+  }
+
+  static headers() {
+    return ChangeStreamsData.headers().concat([
+      { name: "active", printName: "Active", description: "A boolean value specifying whether the operation has started." },
+      { name: "users", printName: "User", description: "Users associated with the operation" },
+      { name: "cursorId", printName: "CursorId", description: "The ID of the cursor." },
+      { name: "createdDate", printName: "CreatedDate", description: "The date and time when the cursor was created." },
+    ]);
+  }
+
+  static help(){
+    const options = {
+      maxSize: process.stdout.columns - 10,
+      borders: [templates.bold, templates.single],
+      columns: [{name: "printName", printName: "Column Name"}, {name: "description", printName: "Description"}],
+      maxDepth: 1,
+      fill: true,
+      inclusive: true,
+    };
+
+    let newTbl = new Table(ExtendedChangeStreamsData.headers(), options);
+    newTbl.print();
+  }
+};
+
+globalThis.ExtendedChangeStreamsData = ExtendedChangeStreamsData;
+
+/**
+ * Retrieves the currently open change streams by running the $currentOp aggregation stage on the admin database.
+ * @param {*} allUsers Boolean that correspond's to the allUsers flag of the $currentOp MongoDB Pipeline Stage i.e. 
+ *                     If set to false, $currentOp only reports on operations/idle connections/idle cursors/idle sessions belonging to the user who ran the command.
+ *                     If set to true, $currentOp reports operations belonging to all users.
+ *                     Defailts to true. 
+ * @param {Array.<string>} nsFilter An optional array of namespace filter. Defaults to [] i.e. to filter.
+ * @returns currently open change streams by running the $currentOp aggregation stage on the admin database
+ */
+globalThis.getChangeStreams = function (allUsers, nsFilter) {
+  //define admin pipeline to extract changestreams
+  let idleConnections = true;
+  let idleCursors = true;
+  let idleSessions = true;
+  let backtrace = true;
+  let localOps = true;
+
+  let pipeline = [
+    {
+      $currentOp: {
+        allUsers: allUsers,
+        idleConnections: idleConnections,
+        idleCursors: idleCursors,
+        idleSessions: idleSessions,
+        backtrace: backtrace,
+        localOps: localOps,
+      },
+    }
+  ]
+
+  let match = {
+    $match: {
+      "cursor.tailable": true,
+      "cursor.originatingCommand.pipeline.0.$changeStream": {
+        $exists: true,
+      },
+    },
+  }
+  if (nsFilter && Array.isArray(nsFilter) && nsFilter.length > 0){
+    match['$match'].ns = {'$in' : nsFilter}
+  }
+  pipeline.push(match)
+
+  //excute pipeline
+  let changeStreamsDataRaw = db
+    .getSiblingDB("admin")
+    .aggregate(pipeline)
+    .toArray();
+  return changeStreamsDataRaw;
+};
+
+/**
+ * Generates a table for the extracted changestream data
+ * @param {*} data The data to be displayed in a table
+ * @param {boolean} extended Whether the extended output format is being used. This is used to generate the output table headers.
+ */
+globalThis.customConsoleTable = function (data, extended) {
+  if (data && data.length > 0) {
+    const options = {
+      maxSize: process.stdout.columns - 10,
+      borders: [templates.bold, templates.single],
+      columns: extended
+        ? ExtendedChangeStreamsData.headers()
+        : ChangeStreamsData.headers(),
+      maxDepth: 1,
+      fill: true,
+      inclusive: true,
+    };
+
+    let newTbl = new Table(data, options);
+    newTbl.print();
+  } else {
+    print("No Change Streams found!");
+  }
+};
+
+
+function _prettyPrintChangeStreamPipeline(connectionId) {
+  let pipeline = [
+    {
+      $currentOp: {
+        allUsers: true,
+        idleConnections: true,
+        idleCursors: true,
+        idleSessions: true,
+        backtrace: true,
+        localOps: true,
+      },
+    },
+    {
+      $match: {
+        connectionId: connectionId,
+      },
+    },
+  ];
+
+  //excute pipeline
+  let changeStreamsDataRaw = db
+    .getSiblingDB("admin")
+    .aggregate(pipeline)
+    .toArray()[0];
+  if (
+    changeStreamsDataRaw &&
+    changeStreamsDataRaw.cursor &&
+    changeStreamsDataRaw.cursor.originatingCommand &&
+    changeStreamsDataRaw.cursor.originatingCommand.pipeline
+  ) {
+    print(changeStreamsDataRaw.cursor.originatingCommand.pipeline);
+  } else {
+    print("Not found");
+  }
+  
+};
+
+function _prettyPrintChangeStreamPipelineHelp(){
+  print("prettyPrintChangeStreamPipeline(connectionId: any): void")
+  print("Pretty prints the Change Stream pipeline for a given Connection ID.")
+  print("\t  * @param {*} connectionId The connection ID where the change stream is executing.")
+}
+
+/**
+ * Pretty prints the Change Stream pipeline for a given Connection ID.
+ * @param {*} connectionId The connection ID where the change stream is executing.
+ */
+globalThis.prettyPrintChangeStreamPipeline = function (connectionId) {
+  _prettyPrintChangeStreamPipeline(connectionId);
+}
+globalThis.prettyPrintChangeStreamPipeline.help = function () {_prettyPrintChangeStreamPipelineHelp();}

--- a/snippets/change-streams-monitor/index.js
+++ b/snippets/change-streams-monitor/index.js
@@ -1,0 +1,3 @@
+(() => {
+  load(__dirname + '/changestreammonitor.js');
+})();

--- a/snippets/change-streams-monitor/package.json
+++ b/snippets/change-streams-monitor/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.12",
   "description": "Mongosh snippet that allows users to monitor Change Streams on the current server.",
   "main": "index.js",
-  "license": "SSPL",
+  "license": "MIT",
   "publishConfig": {
     "access": "public"
   },

--- a/snippets/change-streams-monitor/package.json
+++ b/snippets/change-streams-monitor/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@edmallia/snippet-change-stream-monitor",
+  "name": "@mongosh/snippet-change-stream-monitor",
   "snippetName": "change-stream-monitor",
   "version": "0.0.12",
   "description": "Mongosh snippet that allows users to monitor Change Streams on the current server.",

--- a/snippets/change-streams-monitor/package.json
+++ b/snippets/change-streams-monitor/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@edmallia/snippet-change-stream-monitor",
+  "snippetName": "change-stream-monitor",
+  "version": "0.0.12",
+  "description": "Mongosh snippet that allows users to monitor Change Streams on the current server.",
+  "main": "index.js",
+  "license": "SSPL",
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "to-tabel": "^1.0.3"
+  }
+}

--- a/snippets/change-streams-monitor/package.json
+++ b/snippets/change-streams-monitor/package.json
@@ -9,6 +9,7 @@
     "access": "public"
   },
   "dependencies": {
-    "to-tabel": "^1.0.3"
+    "to-tabel": "^1.0.3",
+    "boks": "^1.0.3"
   }
 }


### PR DESCRIPTION
Add the change-stream-monitor snippet that allows mongosh users to monitor Change Streams on the current server. On installation of this snippet, the following are available to the user.

* listChangeStreams(extended?: boolean, allUsers?: boolean, nsFilter?: Array<string>)
* listChangeStreams.help()
* prettyPrintChangeStreamPipeline(connectionId: any)
* prettyPrintChangeStreamPipeline.help()
* ChangeStreamsData.help()
* ExtendedChangeStreamsData.help()

Further details are available in the README.