### PR TITLE
Add JSON and CSV output to change-stream-monitor snippet

### DIFF
--- a/snippets/change-streams-monitor/README.md
+++ b/snippets/change-streams-monitor/README.md
@@ -6,6 +6,12 @@
     - [Sample Output - Normal Mode](#sample-output---normal-mode)
     - [Sample Output - Extended](#sample-output---extended)
   - [listChangeStreams.help()](#listchangestreamshelp)
+  - [listChangeStreamsAsTable(extended?: boolean, allUsers?: boolean, nsFilter?: Array)](#listchangestreamsastableextended-boolean-allusers-boolean-nsfilter-array)
+  - [listChangeStreamsAsTable.help()](#listchangestreamsastablehelp)
+  - [listChangeStreamsAsJSON(extended?: boolean, allUsers?: boolean, nsFilter?: Array)](#listchangestreamsasjsonextended-boolean-allusers-boolean-nsfilter-array)
+  - [listChangeStreamsAsJSON.help()](#listchangestreamsasjsonhelp)
+  - [listChangeStreamsAsCSV(extended?: boolean, delimiter: string, allUsers?: boolean, nsFilter?: Array)](#listchangestreamsascsvextended-boolean-delimiter-string-allusers-boolean-nsfilter-array)
+  - [listChangeStreamsAsCSV.help()](#listchangestreamsascsvhelp)
   - [prettyPrintChangeStreamPipeline(connectionId: any)](#prettyprintchangestreampipelineconnectionid-any)
     - [Example](#example)
   - [prettyPrintChangeStreamPipeline.help()](#prettyprintchangestreampipelinehelp)
@@ -155,6 +161,24 @@ Found 2 change streams
 ```
 
 ## listChangeStreams.help()
+Provides help on how to use the function.
+
+## listChangeStreamsAsTable(extended?: boolean, allUsers?: boolean, nsFilter?: Array<string>)
+Alias for `listChangeStreams(extended?: boolean, allUsers?: boolean, nsFilter?: Array<string>)`
+
+## listChangeStreamsAsTable.help()
+Provides help on how to use the function. Alias for `listChangeStreams.help()`
+
+## listChangeStreamsAsJSON(extended?: boolean, allUsers?: boolean, nsFilter?: Array<string>)
+Prints the currently open Change Streams as a JSON string. A JSON string is printed separately on a newline for each open Change Stream. The behaviour of the function can be controlled with the available parameters (see parameter defaults for default behaviour). See documentation for `listChangeStreams(extended?: boolean, allUsers?: boolean, nsFilter?: Array<string>)` for more details about the available parameters.
+
+## listChangeStreamsAsJSON.help()
+Provides help on how to use the function.
+
+## listChangeStreamsAsCSV(extended?: boolean, delimiter: string, allUsers?: boolean, nsFilter?: Array<string>)
+Prints the currently open Change Streams as a CSV string with "||||" as the default delimeter. A string is printed separately on a newline for each open Change Stream. The behaviour of the function can be controlled with the available parameters (see parameter defaults for default behaviour). The delimiter parameter allows overriding the default delimiter. See documentation for `listChangeStreams(extended?: boolean, allUsers?: boolean, nsFilter?: Array<string>)` for more details about the other available parameters.
+
+## listChangeStreamsAsCSV.help()
 Provides help on how to use the function.
 
 ## prettyPrintChangeStreamPipeline(connectionId: any)

--- a/snippets/change-streams-monitor/changestreammonitor.js
+++ b/snippets/change-streams-monitor/changestreammonitor.js
@@ -95,7 +95,6 @@ function _listChangeStreams (extended = false, allUsers = true, nsFilter = [], o
       print("Found " + changeStreamsDataRaw.length + " change streams");
       break;
     case OutputTypeEnum.JSON:
-      print("JSON");
       generateJsonOutput(tableData, extended);
       break;
     case OutputTypeEnum.CSV:

--- a/snippets/change-streams-monitor/changestreammonitor.js
+++ b/snippets/change-streams-monitor/changestreammonitor.js
@@ -137,7 +137,7 @@ globalThis.listChangeStreamsAsJSON = function (extended = false, allUsers = true
 //TODO add help
 globalThis.listChangeStreamsAsJSON.help = function () {_listChangeStreamsHelp();}
 
-globalThis.listChangeStreamsAsCSV = function (extended = false, delimiter=DEFAULT_DELIMITER, allUsers = true, nsFilter = []) {_listChangeStreams(extended, allUsers, nsFilter, OutputTypeEnum.CSV, PipelineFormatEnum.JSON);}
+globalThis.listChangeStreamsAsCSV = function (extended = false, delimiter=DEFAULT_DELIMITER, allUsers = true, nsFilter = []) {_listChangeStreams(extended, allUsers, nsFilter, OutputTypeEnum.CSV, PipelineFormatEnum.JSON, delimiter);}
 //TODO add help
 globalThis.listChangeStreamsAsCSV.help = function () {_listChangeStreamsHelp();}
 

--- a/snippets/change-streams-monitor/changestreammonitor.js
+++ b/snippets/change-streams-monitor/changestreammonitor.js
@@ -137,7 +137,7 @@ globalThis.listChangeStreamsAsJSON = function (extended = false, allUsers = true
 //TODO add help
 globalThis.listChangeStreamsAsJSON.help = function () {_listChangeStreamsHelp();}
 
-globalThis.listChangeStreamsAsCSV = function (extended = false, allUsers = true, nsFilter = [], delimiter=DEFAULT_DELIMITER) {_listChangeStreams(extended, allUsers, nsFilter, OutputTypeEnum.CSV, PipelineFormatEnum.JSON);}
+globalThis.listChangeStreamsAsCSV = function (extended = false, delimiter=DEFAULT_DELIMITER, allUsers = true, nsFilter = []) {_listChangeStreams(extended, allUsers, nsFilter, OutputTypeEnum.CSV, PipelineFormatEnum.JSON);}
 //TODO add help
 globalThis.listChangeStreamsAsCSV.help = function () {_listChangeStreamsHelp();}
 

--- a/snippets/change-streams-monitor/changestreammonitor.js
+++ b/snippets/change-streams-monitor/changestreammonitor.js
@@ -107,11 +107,12 @@ function _listChangeStreams (extended = false, allUsers = true, nsFilter = [], o
 
 function _listChangeStreamsHelp(){
   print("listChangeStreams(extended?: boolean, allUsers?: boolean, nsFilter?: any): void")
+  print("listChangeStreamsAsTable(extended?: boolean, allUsers?: boolean, nsFilter?: any): void")
   print("Prints a table with the currently open Change Streams. The behaviour of the function can be controlled with the available parameters (see parameter defaults for default behaviour).")
   print("\t See prettyPrintChangeStreamPipeline.help() to pretty print a change stream pipeline. ")
   print("\t See ChangeStreamsData.help() and ExtendedChangeStreamsData.help() for data outputted in extended and non-extended mode.")
   print("\t @param extended — Controls whether a simple or extended output is presented. Refer to ExtendedChangeStreamsData. Defaults to false.")
-  print("\t @param allUsers — Boolean that correspond's to the allUsers flag of the $currentOp MongoDB Pipeline Stage i.e. If set to false, $currentOp only reports on operations/idle connections/idle cursors/idle sessions belonging to the user who ran the command. If set to true, $currentOp reports operations belonging to all users. Defailts to true.")
+  print("\t @param allUsers — Boolean that correspond's to the allUsers flag of the $currentOp MongoDB Pipeline Stage i.e. If set to false, $currentOp only reports on operations/idle connections/idle cursors/idle sessions belonging to the user who ran the command. If set to true, $currentOp reports operations belonging to all users. Defaults to true.")
   print("\t @param nsFilter — An optional array of namespace filter. Defaults to [] i.e. to filter.")
 }
 
@@ -123,23 +124,68 @@ function _listChangeStreamsHelp(){
  * @param {boolean} allUsers Boolean that correspond's to the allUsers flag of the $currentOp MongoDB Pipeline Stage i.e. 
  *                     If set to false, $currentOp only reports on operations/idle connections/idle cursors/idle sessions belonging to the user who ran the command.
  *                     If set to true, $currentOp reports operations belonging to all users.
- *                     Defailts to true.
+ *                     Defaults to true.
  * @param {Array.<string>} nsFilter An optional array of namespace filter. Defaults to [] i.e. to filter.
  */
 globalThis.listChangeStreams = function (extended = false, allUsers = true, nsFilter = []) {_listChangeStreams(extended, allUsers, nsFilter, OutputTypeEnum.TABLE, PipelineFormatEnum.EJSON);}
 globalThis.listChangeStreams.help = function () {_listChangeStreamsHelp();}
 
+/**
+ * Alias for {@link listChangeStreams}
+ */
 globalThis.listChangeStreamsAsTable = globalThis.listChangeStreams
-//TODO add help
 globalThis.listChangeStreamsAsTable.help = function () {_listChangeStreamsHelp();}
 
-globalThis.listChangeStreamsAsJSON = function (extended = false, allUsers = true, nsFilter = []) {_listChangeStreams(extended, allUsers, nsFilter, OutputTypeEnum.JSON, PipelineFormatEnum.NONE);}
-//TODO add help
-globalThis.listChangeStreamsAsJSON.help = function () {_listChangeStreamsHelp();}
 
+function _listChangeStreamsAsJSONHelp(){
+  print("listChangeStreamsAsJSON(extended?: boolean, allUsers?: boolean, nsFilter?: any): void")
+  print("Prints the currently open Change Streams as a JSON string. A JSON string is printed separately on a newline for each open Change Stream. The behaviour of the function can be controlled with the available parameters (see parameter defaults for default behaviour).")
+  print("\t See prettyPrintChangeStreamPipeline() to pretty print a change stream pipeline. ")
+  print("\t See ChangeStreamsData.help() and ExtendedChangeStreamsData.help() for data outputted in extended and non-extended mode.")
+  print("\t @param extended — Controls whether a simple or extended output is presented. Refer to ExtendedChangeStreamsData. Defaults to false.")
+  print("\t @param allUsers — Boolean that correspond's to the allUsers flag of the $currentOp MongoDB Pipeline Stage i.e. If set to false, $currentOp only reports on operations/idle connections/idle cursors/idle sessions belonging to the user who ran the command. If set to true, $currentOp reports operations belonging to all users. Defaults to true.")
+  print("\t @param nsFilter — An optional array of namespace filter. Defaults to [] i.e. to filter.")
+}
+
+/**
+ * Prints the currently open Change Streams as a JSON string. A JSON string is printed separately on a newline for each open Change Stream. The behaviour of the function can be controlled with the available parameters (see parameter defaults for default behaviour). 
+ * See prettyPrintChangeStreamPipeline() to pretty print a change stream pipeline.
+ * See ChangeStreamsData and ExtendedChangeStreamsData for data outputted in extended and non-extended mode.
+ * @param {boolean} extended Controls whether a simple or extended output is presented. Refer to ExtendedChangeStreamsData. Defaults to false.
+ * @param {boolean} allUsers Boolean that correspond's to the allUsers flag of the $currentOp MongoDB Pipeline Stage i.e. 
+ *                     If set to false, $currentOp only reports on operations/idle connections/idle cursors/idle sessions belonging to the user who ran the command.
+ *                     If set to true, $currentOp reports operations belonging to all users.
+ *                     Defaults to true.
+ * @param {Array.<string>} nsFilter An optional array of namespace filter. Defaults to [] i.e. to filter.
+ */
+globalThis.listChangeStreamsAsJSON = function (extended = false, allUsers = true, nsFilter = []) {_listChangeStreams(extended, allUsers, nsFilter, OutputTypeEnum.JSON, PipelineFormatEnum.NONE);}
+globalThis.listChangeStreamsAsJSON.help = function () {_listChangeStreamsAsJSONHelp();}
+
+
+function _listChangeStreamsAsCSVHelp(){
+  print("listChangeStreamsAsJSON(extended?: boolean, delimiter?: string, allUsers?: boolean, nsFilter?: any): void")
+  print("Prints the currently open Change Streams as a CSV string with \"" + DEFAULT_DELIMITER + "\" as the default delimeter. A string is printed separately on a newline for each open Change Stream. The behaviour of the function can be controlled with the available parameters (see parameter defaults for default behaviour). ")
+  print("\t See prettyPrintChangeStreamPipeline() to pretty print a change stream pipeline. ")
+  print("\t See ChangeStreamsData.help() and ExtendedChangeStreamsData.help() for data outputted in extended and non-extended mode.")
+  print("\t @param extended — Controls whether a simple or extended output is presented. Refer to ExtendedChangeStreamsData. Defaults to false.")
+  print("\t @param delimiter — Provide a custom delimeter for the CSV string. Defaults to \"" + DEFAULT_DELIMITER + "\"")
+  print("\t @param allUsers — Boolean that correspond's to the allUsers flag of the $currentOp MongoDB Pipeline Stage i.e. If set to false, $currentOp only reports on operations/idle connections/idle cursors/idle sessions belonging to the user who ran the command. If set to true, $currentOp reports operations belonging to all users. Defaults to true.")
+  print("\t @param nsFilter — An optional array of namespace filter. Defaults to [] i.e. to filter.")
+}
+/**
+ * Prints the currently open Change Streams as a CSV string with "||||" as the default delimeter. A string is printed separately on a newline for each open Change Stream. The behaviour of the function can be controlled with the available parameters (see parameter defaults for default behaviour). 
+ * See prettyPrintChangeStreamPipeline() to pretty print a change stream pipeline.
+ * See ChangeStreamsData and ExtendedChangeStreamsData for data outputted in extended and non-extended mode.
+ * @param {boolean} extended Controls whether a simple or extended output is presented. Refer to ExtendedChangeStreamsData. Defaults to false.
+ * @param {string} delimiter Provide a custom delimeter for the CSV string
+ * @param {boolean} allUsers Boolean that correspond's to the allUsers flag of the $currentOp MongoDB Pipeline Stage i.e. 
+ *                     If set to false, $currentOp only reports on operations/idle connections/idle cursors/idle sessions belonging to the user who ran the command.
+ *                     If set to true, $currentOp reports operations belonging to all users.
+ *                     Defaults to true.
+ * @param {Array.<string>} nsFilter An optional array of namespace filter. Defaults to [] i.e. to filter.
+ */
 globalThis.listChangeStreamsAsCSV = function (extended = false, delimiter=DEFAULT_DELIMITER, allUsers = true, nsFilter = []) {_listChangeStreams(extended, allUsers, nsFilter, OutputTypeEnum.CSV, PipelineFormatEnum.JSON, delimiter);}
-//TODO add help
-globalThis.listChangeStreamsAsCSV.help = function () {_listChangeStreamsHelp();}
+globalThis.listChangeStreamsAsCSV.help = function () {_listChangeStreamsAsCSVHelp();}
 
 
 /**

--- a/snippets/change-streams-monitor/package.json
+++ b/snippets/change-streams-monitor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mongosh/snippet-change-stream-monitor",
   "snippetName": "change-stream-monitor",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Mongosh snippet that allows users to monitor Change Streams on the current server.",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
Add JSON and CSV output to change-stream-monitor snippet. 

- listChangeStreamsAsTable(extended?: boolean, allUsers?: boolean, nsFilter?: Array<string>) :
Alias for `listChangeStreams(extended?: boolean, allUsers?: boolean, nsFilter?: Array<string>)`
- listChangeStreamsAsJSON(extended?: boolean, allUsers?: boolean, nsFilter?: Array<string>)
- listChangeStreamsAsCSV(extended?: boolean, delimiter: string, allUsers?: boolean, nsFilter?: Array<string>)