### PR TITLE
Fix: `BinData.toString()` wraps base64 in quotes

### DIFF
--- a/snippets/mongocompat/mongotypes.js
+++ b/snippets/mongocompat/mongotypes.js
@@ -548,7 +548,7 @@ if (typeof (BinData) != "undefined") {
         if (encoding) {
             return this.nativeToString(encoding);
         }
-        return `BinData(${this.type}, ${this.base64()})`;
+        return `BinData(${this.type},"${this.base64()}")`;
     };
 
     BinData.prototype.base64 = function () {

--- a/snippets/mongocompat/test.js
+++ b/snippets/mongocompat/test.js
@@ -1,3 +1,4 @@
 load(__dirname + '/index.js');
 
 assert.strictEqual(ObjectId('0123456789abcdef01234567').tojson(), 'ObjectId("0123456789abcdef01234567")');
+assert.strictEqual(BinData(4, 'abcdefgh').toString(), 'BinData(4,"abcdefgh")');


### PR DESCRIPTION
This just aligns more closely with the legacy shell / `$function` in the server.