### PR TITLE
feat: match legacy toString output for NumberDecimal type

### DIFF
--- a/snippets/mongocompat/mongotypes.js
+++ b/snippets/mongocompat/mongotypes.js
@@ -443,14 +443,14 @@ if (typeof NumberDecimal !== 'undefined') {
     if (!NumberDecimal.prototype) {
         NumberDecimal.prototype = {};
     }
+
     NumberDecimal.prototype.nativeToString = NumberDecimal.prototype.toString
-
-    NumberDecimal.prototype.tojson = function() {
-        return this.nativeToString();
-    };
-
     NumberDecimal.prototype.toString = function() {
         return `NumberDecimal("${this.nativeToString()}")`;
+    };
+
+    NumberDecimal.prototype.tojson = function() {
+        return this.toString();
     };
 }
 

--- a/snippets/mongocompat/mongotypes.js
+++ b/snippets/mongocompat/mongotypes.js
@@ -443,9 +443,14 @@ if (typeof NumberDecimal !== 'undefined') {
     if (!NumberDecimal.prototype) {
         NumberDecimal.prototype = {};
     }
+    NumberDecimal.prototype.nativeToString = NumberDecimal.prototype.toString
 
     NumberDecimal.prototype.tojson = function() {
-        return this.toString();
+        return this.nativeToString();
+    };
+
+    NumberDecimal.prototype.toString = function() {
+        return `NumberDecimal("${this.nativeToString()}")`;
     };
 }
 

--- a/snippets/mongocompat/test.js
+++ b/snippets/mongocompat/test.js
@@ -22,3 +22,6 @@ assert.strictEqual(minLong.bottom, 0);
 assert.strictEqual(minLong.exactValueString, "-9223372036854775808");
 const nl2 = NumberLong("200");
 assert.strictEqual(maxLong.compare(nl2), 1);
+const decimal = NumberDecimal("1.1");
+assert.strictEqual(decimal.toString(), 'NumberDecimal("1.1")');
+assert.strictEqual(decimal.tojson(), '1.1');

--- a/snippets/mongocompat/test.js
+++ b/snippets/mongocompat/test.js
@@ -24,4 +24,4 @@ const nl2 = NumberLong("200");
 assert.strictEqual(maxLong.compare(nl2), 1);
 const decimal = NumberDecimal("1.1");
 assert.strictEqual(decimal.toString(), 'NumberDecimal("1.1")');
-assert.strictEqual(decimal.tojson(), '1.1');
+assert.strictEqual(decimal.tojson(), 'NumberDecimal("1.1")');


### PR DESCRIPTION
Match output with legacy mongo shell for toString method

Jira ticket: https://jira.mongodb.org/browse/STREAMS-1983