### PR TITLE
chore: fixups for the ai snippet

### DIFF
--- a/snippets/ai/package-lock.json
+++ b/snippets/ai/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@gagik.co/snippet-ai",
-  "version": "0.1.2",
+  "name": "@mongosh/snippet-ai",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@gagik.co/snippet-ai",
-      "version": "0.0.13",
+      "name": "@mongosh/snippet-ai",
+      "version": "0.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/mistral": "^2.0.20",

--- a/snippets/ai/tsconfig.json
+++ b/snippets/ai/tsconfig.json
@@ -15,6 +15,6 @@
     "allowJs": true,
     "resolveJsonModule": true
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "src/index.js"],
   "exclude": ["src/**/*.test.ts"]
 }


### PR DESCRIPTION
Somehow missed the fact that index.js ended up excluded from the bundle